### PR TITLE
CORE-401 Bugfix: record names with forward slash

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,6 +44,8 @@ rules:
   no-param-reassign:
     - error
     - props: false
+  no-plusplus:
+    - 0
   no-restricted-syntax:
     - warn
   no-tabs:
@@ -64,6 +66,8 @@ rules:
     - warn
   object-curly-spacing:
     - warn
+  padded-blocks:
+    - 0
   prefer-const:
     - error
   prefer-template:

--- a/util/file-naming.js
+++ b/util/file-naming.js
@@ -1,6 +1,17 @@
-const pathToRegexp = require('path-to-regexp');
 const _ = require('lodash');
+const pathToRegexp = require('path-to-regexp');
 const { parseConfigFile } = require('./config');
+
+// characters found in the record name that will be replaced
+const replaceFileNameRe = [
+  { toReplace: new RegExp('-', 'g'), replaceWith: '^' }
+  // { toReplace: new RegExp('/', 'g'), replaceWith: '%' } // throwing an error instead
+];
+
+// characters found in the record name that will throw an error
+const errorFileNameRe = [
+  /\//g
+];
 
 /**
  * Compiles a now-sync file name using a given file template and record data.
@@ -17,8 +28,20 @@ function compileFileName(fileTemplate, data) {
     }
 
     let tokenFromData = data[token.name];
-    if (tokenFromData.indexOf('-') !== -1) {
-      tokenFromData = tokenFromData.replace(/-/g, '^');
+    let i;
+    for (i = 0; i < errorFileNameRe.length; i++) {
+      const errorFileNameReExec = errorFileNameRe[i].exec(tokenFromData);
+      if (errorFileNameReExec) {
+        throw new Error(`Invalid character "${errorFileNameReExec[0]}" found in the record’s \`${token.name}\` field. Change your record’s \`${token.name}\` field value and try again.`);
+      }
+    }
+
+    for (i = 0; i < replaceFileNameRe.length; i++) {
+      const replaceChar = replaceFileNameRe[i];
+
+      if (replaceChar.toReplace.test(tokenFromData)) {
+        tokenFromData = tokenFromData.replace(replaceChar.toReplace, replaceChar.replaceWith);
+      }
     }
     return tokenFromData;
   });

--- a/util/file-naming.test.js
+++ b/util/file-naming.test.js
@@ -1,0 +1,51 @@
+const { compileFileName } = require('./file-naming');
+
+describe('util/file-naming', () => {
+
+  describe('compileFileName()', () => {
+    test('correctly compiles file name from correct data', () => {
+      const fileTemplate = ':name-script-:sys_id.js';
+      const data = {
+        sys_id: 'f224f2a51322fa00ca1e70a76144b072',
+        name: 'x_ctv_sc.common',
+        sys_updated_on: '2017-07-18 01:54:41',
+        script: ''
+      };
+
+      expect(compileFileName(fileTemplate, data)).toEqual('x_ctv_sc.common-script-f224f2a51322fa00ca1e70a76144b072.js');
+    });
+
+    test('“-” in the record name is replaced with “^” in the file name', () => {
+      const fileTemplate = ':name-script-:sys_id.js';
+      const data = {
+        sys_id: '1d58db6213233a00ca1e70a76144b090',
+        name: 'x_ctv_dev.update-sets-release-tool',
+        sys_updated_on: '2017-06-27 15:52:26',
+        script: ''
+      };
+
+      expect(compileFileName(fileTemplate, data)).toEqual('x_ctv_dev.update^sets^release^tool-script-1d58db6213233a00ca1e70a76144b090.js');
+    });
+
+    test('“/” in the record name throws an error', () => {
+      const fileTemplate = ':collection-:name-script-:sys_id.js';
+      const data = {
+        sys_id: '0df8452113044700ca1e70a76144b098',
+        name: '_CTV_Re-Calculate Fees (ins/updt)',
+        collection: 'x_ctv_sc_po_line_item',
+        sys_updated_on: '2017-07-18 23:57:18',
+        script: ''
+      };
+
+      let errorThrown = false;
+      try {
+        compileFileName(fileTemplate, data);
+      } catch (e) {
+        errorThrown = true;
+      }
+
+      expect(errorThrown).toBe(true);
+    });
+
+  });
+});


### PR DESCRIPTION
* Trying to add a file with a `/` in its corresponding record’s name field now throws an error.